### PR TITLE
Replace non-standard malloc.h header; use char literals

### DIFF
--- a/command-list.txt
+++ b/command-list.txt
@@ -38,7 +38,7 @@ ltl		ret		Return
 lll		quit		End
 
 // *** These two added later -- V0.3
-//     "N-pick (Copy/Ref) is just like Forth (excpet it uses a constant);
+//     "N-pick (Copy/Ref) is just like Forth (except it uses a constant);
 //     "N-slide" is a limited substitute for ROT.
 //     The "N" must be positive so only valid forms are "stls" and "stss"
 

--- a/ws2c.c
+++ b/ws2c.c
@@ -419,9 +419,9 @@ char * cv_label(char * ws_label)
 	    if (*s != ' ')
 		i ++;
 	    if (++j == 8) {
-		if (i>=48 && i<=57 && n != 0) {
+		if (i>='0' && i<='9' && n != 0) {
 		    sbuf[n++] = i;
-		} else if ( (i>=65 && i<=90) || (i>=97 && i<=122) || i==95) {
+		} else if ( (i>='A' && i<='Z') || (i>='a' && i<='z') || i=='_') {
 		    sbuf[n++] = i;
 		} else {
 		    n = 0;

--- a/ws_gencode.h
+++ b/ws_gencode.h
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #ifndef BIJECTIVE
 #define BIJECTIVE 0


### PR DESCRIPTION
This PR replaces the non-standard header `malloc.h` with `stdlib.h` to resolve compilation failure with Clang and match other files. It also replaces some byte values with char literals to improve readability.

You may be interested in the [Whitespace Corpus](https://github.com/wspace/corpus), which documents many (~200) Whitespace interpreters, compilers, and programs, including yours.